### PR TITLE
allowing for compliance calls for (true)leads 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Status indicator for compliance status.
 
 Takes the following attributes:
 
-  * cmId
+  * cmId (optional)
+  * leadId (optional) ** you must supply either cmId or leadId
   * projectId
   * contactId (optional)
   * ruleSet (optional)

--- a/demo.html
+++ b/demo.html
@@ -33,6 +33,12 @@
       <glg-compliance-blinky cmId="527313" projectId="1994800"></glg-compliance-blinky>
       Here is some text after to show the alignment things.
     </p>
+
+    <p>
+      What's the compliance status for Lead 1679013 on project 1994800?
+      <glg-compliance-blinky leadId="1679013" projectId="1994800"></glg-compliance-blinky>
+      Here is some text after to show the alignment things.
+    </p>
     <p>
       What about when there's no project at all?
       <glg-compliance-blinky cmId="527313" projectId=""></glg-compliance-blinky>

--- a/src/glg-compliance-blinky.html
+++ b/src/glg-compliance-blinky.html
@@ -1,12 +1,12 @@
 <link rel="import" href="../node_modules/core-ajax-npm/core-ajax.html">
 <link rel="import" href="../node_modules/ui-tooltip/src/ui-tooltip.html">
-<polymer-element name="glg-compliance-blinky" attributes="cmId projectId contactId ruleSet">
+<polymer-element name="glg-compliance-blinky" attributes="cmId leadId projectId contactId ruleSet">
   <template>
     <link rel="stylesheet" type="text/css" href="./glg-compliance-blinky.less">
     <core-ajax
       auto
       url="https://services.glgresearch.com/compliance-epi/api/{{ruleSet}}validate/"
-      params='{"src":"glg-compliance-blinky","cmIds":"{{cmId}}","projectId":"{{projectId}}","contactId":"{{contactId}}"}'
+      params='{"src":"glg-compliance-blinky","cmIds":"{{cmId}}","leadIds":"{{leadId}}","projectId":"{{projectId}}","contactId":"{{contactId}}"}'
       handleAs="json"
       withCredentials="true"
       on-core-response="{{onResponse}}"


### PR DESCRIPTION
This is a temporary fix for blinky, allowing leadIds to be passed in, until leads truly go away.
